### PR TITLE
Fixed bug where progress goal line was missing

### DIFF
--- a/survey_progress.html
+++ b/survey_progress.html
@@ -57,6 +57,9 @@ layout: default
 				}else{
 					var elem = document.getElementsByClassName("progress-bar-marker")[0];
 					elem.style.width = totneeded - width + "%";
+                    let redwidth = (1/4)/(totneeded-width)*100;
+		            let remainwidth = (totneeded-width-(1/4))/(totneeded-width)*100;
+		            elem.style.backgroundImage = 'linear-gradient(90deg, rgba(225,225,225,0.1) ' + remainwidth + '%, rgba(204,0,0,1) ' + redwidth + '%)';
 				}
 
     })


### PR DESCRIPTION
Changed the calculation of the goal line positioning to based on the width of a single percentage across the whole progress bar rather than relative to the width of the 'remaining' bar.