### PR TITLE
Survey Progress bar for current year and Documentation

### DIFF
--- a/Survey_Progress_Setup.md
+++ b/Survey_Progress_Setup.md
@@ -1,0 +1,16 @@
+# Setting up the Progress Bar for the GSA Survey
+
+Most of the functionality is already there for implementing the survey progress bar, we just need to setup a Google Doc website that shows the current number of responses to the survey and then adjust the current number of students in the program in the `survey_progress.html` document.
+
+1) In the new survey google form that you are going to send out, go to the responses tab and create a google sheet for the form responses
+2) Create a second page on the google form and name it something like `responsecount` (not sure that the name really matters here)
+3) In cell `A1` of the `responsecount` page create an equation of the form
+    ```
+    =COUNT('Form Responses 1'!A:A)
+    ```
+    It should read whatever number of responses the form currently has.
+4) In the help bar of the google sheet, search for "Publish to web" and then publish ONLY the `responsecount` page as a web page.
+5) Copy the URL of the published web page.
+6) Edit the `survey_progress.html` page and change the URL in the javascript to the published page that you just copied.
+7) Then adjust the `totstu` variable to the current number of students in the program.
+8) (Optional) Adjust the success text to whatever the reward is for reaching 80% participation

--- a/survey_progress.html
+++ b/survey_progress.html
@@ -11,7 +11,7 @@ layout: default
 <div id="complete">
 </div>
 <script>
-	fetch('https://docs.google.com/spreadsheets/d/e/2PACX-1vQSskiQhmJeADX7PbyY_uyH3ZlDafR2egDaiw-FHjB_CUaYSdvZo4reSaw_GBxAL8qwAnDkYztsGEDN/pubhtml?gid=2050786915&single=true')
+	fetch('https://docs.google.com/spreadsheets/d/e/2PACX-1vR-sEr2lWDEdCNU4lCUvmOV7t3OuoMRx8cYHpBaveJChxoTRDri5UkcHImGlFZ0_1fQixLsChlolomC/pubhtml?gid=90770309&single=true')
     .then(function(response) {
         // When the page is loaded convert it to text
         return response.text()
@@ -24,8 +24,8 @@ layout: default
         var doc = parser.parseFromString(html, "text/html");
 
         let curprog = doc.getElementsByClassName("s0")[0].textContent;
-				let totstu = 86;
-				let totneeded = 80;
+				let totstu = 88;
+				let totneeded = Math.ceil(0.8*totstu);
 
 				var elem = document.getElementsByClassName("progress-bar progress-bar-striped")[0];
 				let width = curprog/totstu*100;


### PR DESCRIPTION
Added documentation for setting up the `survey_progress.html` page with a new student survey. Edited the current `survey_progress.html` with the current number of students in the program and the link to the published document of the count.